### PR TITLE
Minor changes to jupyter tutorial to make it work with python3

### DIFF
--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -34,9 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -49,15 +47,13 @@
    "source": [
     "from fretboard import *\n",
     "c = Note('C')\n",
-    "print c"
+    "print (c)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -77,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -99,9 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -128,9 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -159,9 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -173,7 +161,7 @@
    ],
    "source": [
     "f = c + 5\n",
-    "print f"
+    "print (f)"
    ]
   },
   {
@@ -186,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -200,7 +186,7 @@
    ],
    "source": [
     "ff = f + 12\n",
-    "print ff"
+    "print (ff)"
    ]
   },
   {
@@ -215,9 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -228,7 +212,7 @@
     }
    ],
    "source": [
-    "print ff - c"
+    "print (ff - c)"
    ]
   },
   {
@@ -241,9 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -254,15 +236,13 @@
     }
    ],
    "source": [
-    "print c.interval(f)"
+    "print (c.interval(f))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -273,7 +253,7 @@
     }
    ],
    "source": [
-    "print f.interval(c)"
+    "print (f.interval(c))"
    ]
   },
   {
@@ -288,9 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -302,7 +280,7 @@
    ],
    "source": [
     "c_maj = Major('C')\n",
-    "print c_maj"
+    "print (c_maj)"
    ]
   },
   {
@@ -315,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -329,7 +305,7 @@
    ],
    "source": [
     "c_min = Diatonic('C', mode=6)\n",
-    "print c_min"
+    "print (c_min)"
    ]
   },
   {
@@ -342,9 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -356,7 +330,7 @@
    ],
    "source": [
     "a_pmin = MinorPentatonic('A')\n",
-    "print a_pmin"
+    "print (a_pmin)"
    ]
   },
   {
@@ -369,9 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -383,7 +355,7 @@
    ],
    "source": [
     "a_blues = Blues('A')\n",
-    "print a_blues"
+    "print (a_blues)"
    ]
   },
   {
@@ -396,9 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -418,9 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -447,9 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -460,7 +426,7 @@
     }
    ],
    "source": [
-    "print a_blues.get_interval_name('G')"
+    "print (a_blues.get_interval_name('G'))"
    ]
   },
   {
@@ -475,9 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -502,9 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -550,9 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -585,9 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -620,9 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -658,9 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -674,7 +628,7 @@
       "A      ||---|---|-C-|---|---|\n",
       "E     x||---|---|---|---|---|\n",
       "        =====================\n",
-      "                  3     \n"
+      "                  3       5 \n"
      ]
     }
    ],
@@ -696,9 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -712,35 +664,35 @@
       "A      ||---|---|-C-|---|---|\n",
       "E     x||---|---|---|---|---|\n",
       "        =====================\n",
-      "                  3     \n"
+      "                  3       5 \n"
      ]
     }
    ],
    "source": [
     "text = c.get_display(fmax=5)\n",
-    "print text"
+    "print (text)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
print() has been updated for python3 syntax.